### PR TITLE
refactor: tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "silent-payments",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "SilentPayments (BIP-352) in pure typescript",
   "main": "src/index.ts",
   "scripts": {
+    "tslint": "tsc src/index.ts --noEmit --skipLibCheck --target esnext --moduleResolution nodenext --module NodeNext ",
     "test": "vitest run tests/"
   },
   "author": "overtorment",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add runtime assertions and safer EC ops in UTXO detection and seed derivation, plus a tsc lint script and patch version bump.
> 
> - **Core (`src/index.ts`)**:
>   - Add runtime `assert` checks in `seedToCode` for `bscan`/`bspend` derivation.
>   - Refactor EC math in `detectOurUtxos` and `detectOurUtxosUsingTweakbscanBspend` by separating `tkG` computation and asserting results before `pointAdd`.
>   - Define a local `assert` helper.
>   - Minor typing refinement: return `Omit<UTXO,'wif'>` in `detectOurUtxosUsingTweakbscanBspend`.
> - **Build/Meta**:
>   - Add `tslint` script (`tsc ... --noEmit`).
>   - Bump version to `2.2.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53dff0460d1ef1f20e18fcefbb3fe0abd8c0bb97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->